### PR TITLE
test readthedocs without building PnetCDF-Python package

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,14 +10,7 @@ build:
     python: "3.10"
   jobs:
     pre_install:
-      - echo "CC=$CC"
-      - echo "PNETCDF_VER=$PNETCDF_VER"
-      - echo "Download and build PnetCDF version $PNETCDF_VER"
-      - wget https://parallel-netcdf.github.io/Release/pnetcdf-$PNETCDF_VER.tar.gz
-      - tar -xzf pnetcdf-$PNETCDF_VER.tar.gz
-      - echo "Installing PnetCDF-C in PNETCDF_DIR=$PNETCDF_DIR"
-      - cd ./pnetcdf-$PNETCDF_VER ; ./configure --prefix=${PNETCDF_DIR} --enable-shared --enable-debug --disable-fortran --disable-cxx; make -j 8 install
-      - pip install numpy cython cftime pytest twine wheel check-manifest mpi4py
+      - pip install numpy cython cftime pytest twine wheel check-manifest
 
 python:
   install:


### PR DESCRIPTION
readthedocs CI is only triggered when a PR is created in the original repo, not a fork.